### PR TITLE
Modified the RM module and sample to  use Service Principal

### DIFF
--- a/src/AzureAutomationVsoGitSync/Samples/Sync-AzureRMRunbooks.ps1
+++ b/src/AzureAutomationVsoGitSync/Samples/Sync-AzureRMRunbooks.ps1
@@ -15,18 +15,12 @@
 
 		[Parameter(Mandatory=$True)]
 		[string] $VSORunbookFolderPath,
-	   
-		[Parameter(Mandatory=$True)]
-		[string] $TargetSubscriptionId,
        
 		[Parameter(Mandatory=$True)]
 		[string] $TargetResourceGroup,
 
 		[Parameter(Mandatory=$True)]
 		[string] $TargetAutomationAccount,
-
-		[Parameter(Mandatory=$True)]
-		[string] $TargetCredentialName,
 
 		[Parameter(Mandatory=$True)]
 		[string] $VSOBranch,


### PR DESCRIPTION
Joe, please take a look. My version uses a Service Principal (stored in Automation Account variables) versus a Credential object. Ideally, the user would be able to choose which one they want to use.